### PR TITLE
add vanilla kit to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ A collection of awesome things regarding [Frameworkless](https://github.com/fram
 
 * [frameworkless.js](https://frameworkless.js.org/) by Mike Timofiiv
 
+### Kit
+
+* [https://github.com/p-it-nl/vanilla-kit] A minimalist, dependency-light vanilla JS starter kit — framework-free and no node modules required.
+
 ### UI Library
 
 * [Corex](https://netoum.com/corex/documentation/introduction.html) A Pure HTML, Vanilla JS &  CSS UI Component Library

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A collection of awesome things regarding [Frameworkless](https://github.com/fram
 
 ### Kit
 
-* [https://github.com/p-it-nl/vanilla-kit] A minimalist, dependency-light vanilla JS starter kit — framework-free and no node modules required.
+* [VanillaKit](https://github.com/p-it-nl/vanilla-kit) A minimalist, dependency-light vanilla JS starter kit — framework-free and no node modules required.
 
 ### UI Library
 


### PR DESCRIPTION
This PR adds a plug for VanillaKit, a minimalist and dependency-light vanilla JS starter kit, to the README. 

I believe it fits well with the frameworkless movement and could be a useful addition for others exploring lightweight frontend options.
